### PR TITLE
fix token handling for rag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,68 @@
+AKS_NAME ?= 'kaito-pr-agent'
+RESOURCE_GROUP ?= 'kaito-pr-agent'
+SUBNET_ADDRESS_PREFIX ?= '10.225.0.0/24'
+ALB_SUBNET_NAME ?= 'subnet-alb' # subnet name can be any non-reserved subnet name (i.e. GatewaySubnet, AzureFirewallSubnet, AzureBastionSubnet would all be invalid)
+IDENTITY_RESOURCE_NAME ?= 'azure-alb-identity'
+HELM_NAMESPACE ?= 'default'
+CONTROLLER_NAMESPACE ?= 'azure-alb-system'
+
+setup-agc: create-alb-identity create-alb-subnet install-alb-controller apply-agc-resources
+
+.PHONY: create-alb-identity
+create-alb-identity:
+	mcResourceGroup=$(az aks show --resource-group $RESOURCE_GROUP --name $AKS_NAME --query "nodeResourceGroup" -o tsv)
+	mcResourceGroupId=$(az group show --name $mcResourceGroup --query id -otsv)
+
+	echo "Creating identity $IDENTITY_RESOURCE_NAME in resource group $RESOURCE_GROUP"
+	az identity create --resource-group $RESOURCE_GROUP --name $IDENTITY_RESOURCE_NAME
+	principalId="$(az identity show -g $RESOURCE_GROUP -n $IDENTITY_RESOURCE_NAME --query principalId -otsv)"
+
+	echo "Waiting 60 seconds to allow for replication of the identity..."
+	sleep 60
+
+	echo "Apply Reader role to the AKS managed cluster resource group for the newly provisioned identity"
+	az role assignment create --assignee-object-id $principalId --assignee-principal-type ServicePrincipal --scope $mcResourceGroupId --role "acdd72a7-3385-48ef-bd42-f606fba81ae7" # Reader role
+
+	echo "Set up federation with AKS OIDC issuer"
+	AKS_OIDC_ISSUER="$(az aks show -n "$AKS_NAME" -g "$RESOURCE_GROUP" --query "oidcIssuerProfile.issuerUrl" -o tsv)"
+	az identity federated-credential create --name "azure-alb-identity" --identity-name "$IDENTITY_RESOURCE_NAME" --resource-group $RESOURCE_GROUP --issuer "$AKS_OIDC_ISSUER" --subject "system:serviceaccount:azure-alb-system:alb-controller-sa"
+
+.PHONY: install-alb-controller
+install-alb-controller:
+	az aks get-credentials --resource-group $RESOURCE_GROUP --name $AKS_NAME
+	helm install alb-controller oci://mcr.microsoft.com/application-lb/charts/alb-controller --namespace $HELM_NAMESPACE --version 1.7.9 --set albController.namespace=$CONTROLLER_NAMESPACE --set albController.podIdentity.clientID=$(az identity show -g $RESOURCE_GROUP -n azure-alb-identity --query clientId -o tsv)
+
+.PHONY: create-alb-subnet
+create-alb-subnet:
+	MC_RESOURCE_GROUP=$(az aks show --name $AKS_NAME --resource-group $RESOURCE_GROUP --query "nodeResourceGroup" -o tsv)
+	CLUSTER_SUBNET_ID=$(az vmss list --resource-group $MC_RESOURCE_GROUP --query '[0].virtualMachineProfile.networkProfile.networkInterfaceConfigurations[0].ipConfigurations[0].subnet.id' -o tsv)
+	VNET_NAME=$(az network vnet show --ids $CLUSTER_SUBNET_ID --query 'name' -o tsv)
+	VNET_RESOURCE_GROUP=$(az network vnet show --ids $CLUSTER_SUBNET_ID --query 'resourceGroup' -o tsv)
+	VNET_ID=$(az network vnet show --ids $CLUSTER_SUBNET_ID --query 'id' -o tsv)
+
+	az network vnet subnet create \
+	--resource-group $VNET_RESOURCE_GROUP \
+	--vnet-name $VNET_NAME \
+	--name $ALB_SUBNET_NAME \
+	--address-prefixes $SUBNET_ADDRESS_PREFIX \
+	--delegations 'Microsoft.ServiceNetworking/trafficControllers'
+	ALB_SUBNET_ID=$(az network vnet subnet show --name $ALB_SUBNET_NAME --resource-group $VNET_RESOURCE_GROUP --vnet-name $VNET_NAME --query '[id]' --output tsv)
+
+	MC_RESOURCE_GROUP=$(az aks show --name $AKS_NAME --resource-group $RESOURCE_GROUP --query "nodeResourceGroup" -otsv | tr -d '\r')
+
+	mcResourceGroupId=$(az group show --name $MC_RESOURCE_GROUP --query id -otsv)
+	principalId=$(az identity show -g $RESOURCE_GROUP -n $IDENTITY_RESOURCE_NAME --query principalId -otsv)
+
+	# Delegate AppGw for Containers Configuration Manager role to AKS Managed Cluster RG
+	az role assignment create --assignee-object-id $principalId --assignee-principal-type ServicePrincipal --scope $mcResourceGroupId --role "fbc52c3f-28ad-4303-a892-8a056630b8f1"
+
+	# Delegate Network Contributor permission for join to association subnet
+	az role assignment create --assignee-object-id $principalId --assignee-principal-type ServicePrincipal --scope $ALB_SUBNET_ID --role "4d97b98b-1d4f-4787-a291-c67834d212e7"
+
+.PHONY: apply-agc-resources
+apply-agc-resources:
+	ALB_SUBNET_ID=$(az network vnet subnet show --name $ALB_SUBNET_NAME --resource-group $VNET_RESOURCE_GROUP --vnet-name $VNET_NAME --query '[id]' --output tsv)
+	az aks get-credentials --resource-group $RESOURCE_GROUP --name $AKS_NAME --overwrite-existing
+	k apply -f deploy/agc/applicationloadbalancer.yaml
+	k apply -f deploy/agc/gateway.yaml
+	k apply -f deploy/agc/httproute.yaml

--- a/deploy/agc/applicationloadbalancer.yaml
+++ b/deploy/agc/applicationloadbalancer.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: alb-test-infra
+  name: alb-infra
 ---
 apiVersion: alb.networking.azure.io/v1
 kind: ApplicationLoadBalancer
 metadata:
-  name: alb-test
-  namespace: alb-test-infra
+  name: pr-agent-alb
+  namespace: alb-infra
 spec:
   associations:
   - $ALB_SUBNET_ID

--- a/deploy/agc/gateway.yaml
+++ b/deploy/agc/gateway.yaml
@@ -1,12 +1,11 @@
-# Follow along first here: https://learn.microsoft.com/en-us/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller?tabs=install-helm-windows
-# Then here to get things setup: https://learn.microsoft.com/en-us/azure/application-gateway/for-containers/quickstart-create-application-gateway-for-containers-managed-by-alb-controller?tabs=new-subnet-aks-vnet
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   name: pr-agent-gateway
-  namespace: default
+  namespace: alb-infra
   annotations:
-    alb.networking.azure.io/alb-id: $RESOURCE_ID
+    alb.networking.azure.io/alb-namespace: alb-infra
+    alb.networking.azure.io/alb-name: pr-agent-alb
 spec:
   gatewayClassName: azure-alb-external  # this GatewayClass was created by ALB controller
   listeners:
@@ -16,6 +15,3 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
-  addresses:
-  - type: alb.networking.azure.io/alb-frontend
-    value: $FRONTEND_NAME

--- a/deploy/agc/httproute.yaml
+++ b/deploy/agc/httproute.yaml
@@ -27,22 +27,3 @@ spec:
       backendRefs:
         - name: pr-agent-service
           port: 80
-
-
-# apiVersion: gateway.networking.k8s.io/v1beta1
-# kind: HTTPRoute
-# metadata:
-#   name: pr-agent-app-route
-#   namespace: default
-# spec:
-#   parentRefs:
-#     - name: pr-agent-gateway
-#       namespace: default
-#   rules:
-#     - matches:
-#         - path:
-#             type: PathPrefix
-#             value: /
-#       backendRefs:
-#         - name: nginx-test-service
-#           port: 80

--- a/deploy/k8s/kaito-ragengine.yaml
+++ b/deploy/k8s/kaito-ragengine.yaml
@@ -1,0 +1,15 @@
+apiVersion: kaito.sh/v1alpha1
+kind: RAGEngine
+metadata:
+  name: ragengine
+spec:
+  compute:
+    instanceType: "Standard_NC24ads_A100_v4"
+    labelSelector:
+      matchLabels:
+        apps: ragengine
+  embedding:
+    local:
+      modelID: "BAAI/bge-small-en-v1.5"
+  inferenceService:
+    url: "http://workspace-qwen-2-5-coder-32b-instruct.default.svc/v1/chat/completions"

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -410,6 +410,7 @@ class LiteLLMAIHandler(BaseAiHandler):
                 if await self.pr_rag_engine.is_valid_pr_base_branch():
                     get_logger().info(f"Base branch is valid for PR URL {self.pr_rag_engine.pr_url}. adding index name to request for RAG features.")
                     kwargs["index_name"] = await self.pr_rag_engine.get_pr_head_index_name()
+                    kwargs["max_tokens"] = get_settings().config.custom_model_max_tokens
 
             # Fall back to regular acompletion if PRRagEngine is not available or failed
             response = await acompletion(**kwargs)

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -410,7 +410,13 @@ class LiteLLMAIHandler(BaseAiHandler):
                 if await self.pr_rag_engine.is_valid_pr_base_branch():
                     get_logger().info(f"Base branch is valid for PR URL {self.pr_rag_engine.pr_url}. adding index name to request for RAG features.")
                     kwargs["index_name"] = await self.pr_rag_engine.get_pr_head_index_name()
-                    kwargs["max_tokens"] = get_settings().config.custom_model_max_tokens
+                    request_max_tokens = await self.pr_rag_engine.get_request_max_tokens(
+                        max_tokens=get_settings().config.custom_model_max_tokens,
+                        system=system,
+                        user=user
+                    )
+                    get_logger().info(f"setting max tokens to {request_max_tokens} for RAG features.")
+                    kwargs["max_tokens"] = request_max_tokens
 
             # Fall back to regular acompletion if PRRagEngine is not available or failed
             response = await acompletion(**kwargs)

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -372,3 +372,4 @@ use_rag_engine=false
 rag_engine_url=""
 enabled_base_branches = ["main"]
 ignore_directories = [".github/"]
+token_buffer=2500

--- a/pr_agent/tools/pr_rag_engine.py
+++ b/pr_agent/tools/pr_rag_engine.py
@@ -3,12 +3,15 @@ import os
 
 from pr_agent.algo.types import EDIT_TYPE
 from pr_agent.clients.kaito_rag_client import KAITORagClient
+from pr_agent.config_loader import get_settings
 from pr_agent.git_providers import (get_git_provider,
                                     get_git_provider_with_context)
 from pr_agent.tools.pr_rag_index_manager import PRRAGIndexManager
+from pr_agent.algo.token_handler import TokenHandler
 
 from ..log import get_logger
 
+RAG_BUFFER_TOKENS = get_settings().config.get("KAITORAGENGINE.TOKEN_BUFFER", 2500)
 
 class PRRAGEngine:
     '''
@@ -56,6 +59,24 @@ class PRRAGEngine:
             raise ValueError(f"Git provider not found for PR URL: {self.pr_url}")
 
         return self.index_manager._get_pr_base_index_name(git_provider)
+    
+    async def get_request_max_tokens(self, max_tokens: int, system: str = "", user: str = ""):
+        """
+        Get the maximum tokens allowed for the request based on the model and rag buffer.
+
+        Returns:
+            int: The maximum tokens allowed for the request.
+
+        Raises:
+            ValueError: If the model is not supported.
+        """
+
+        git_provider = self.index_manager._get_git_provider(self.pr_url)
+        if not git_provider:
+            raise ValueError(f"Git provider not found for PR URL: {self.pr_url}")
+
+        token_handler = TokenHandler(git_provider.pr, {}, system, user)
+        return max_tokens - token_handler.prompt_tokens - RAG_BUFFER_TOKENS
 
     async def query(self, query: str, llm_temperature: float = 0.7, llm_max_tokens: int = 1000, top_k: int = 5):
         """


### PR DESCRIPTION
The `max_tokens` param sets the potential max output, but will error if it is set to the entire context window of the LLM. This adds handling on RAG calls to update the `max_tokens` from the total to a smaller size with rag token buffer.

Also added Makefile for simplifying agc creation, and updated the corresponding k8s components.