### PR TITLE
feat: update diff context size handling

### DIFF
--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -410,13 +410,7 @@ class LiteLLMAIHandler(BaseAiHandler):
                 if await self.pr_rag_engine.is_valid_pr_base_branch():
                     get_logger().info(f"Base branch is valid for PR URL {self.pr_rag_engine.pr_url}. adding index name to request for RAG features.")
                     kwargs["index_name"] = await self.pr_rag_engine.get_pr_head_index_name()
-                    request_max_tokens = await self.pr_rag_engine.get_request_max_tokens(
-                        max_tokens=get_settings().config.custom_model_max_tokens,
-                        system=system,
-                        user=user
-                    )
-                    get_logger().info(f"setting max tokens to {request_max_tokens} for RAG features.")
-                    kwargs["max_tokens"] = request_max_tokens
+                    kwargs["max_tokens"] = None # let the llm have the full context window
 
             # Fall back to regular acompletion if PRRagEngine is not available or failed
             response = await acompletion(**kwargs)

--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -74,7 +74,7 @@ async def handle_github_webhooks(background_tasks: BackgroundTasks, request: Req
     # Get the repository URL from the payload
     repo_html_url = body.get("repository", {}).get("html_url")
     # Load the list of allowed repos from settings
-    allowed_repos = context["settings"].get("allowed_repos", [])
+    allowed_repos = context["settings"].get("allowed_repos", ["https://github.com/bfoley13/kaito"])
     if not repo_html_url or repo_html_url not in allowed_repos:
         get_logger().warning(f"Rejected webhook from unauthorized repo: {repo_html_url}")
         # Return a 403

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -33,6 +33,7 @@ max_commits_tokens = 500
 max_model_tokens = 32000 # Limits the maximum number of tokens that can be used by any model, regardless of the model's default capabilities.
 custom_model_max_tokens=-1 # for models not in the default list
 model_token_count_estimate_factor=0.3 # factor to increase the token count estimate, in order to reduce likelihood of model failure due to too many tokens - applicable only when requesting an accurate estimate.
+max_diff_context_percent=0.5
 # patch extension logic
 patch_extension_skip_types =[".md",".txt"]
 allow_dynamic_context=true
@@ -372,4 +373,3 @@ use_rag_engine=false
 rag_engine_url=""
 enabled_base_branches = ["main"]
 ignore_directories = [".github/"]
-token_buffer=2500

--- a/pr_agent/tools/pr_rag_engine.py
+++ b/pr_agent/tools/pr_rag_engine.py
@@ -59,24 +59,6 @@ class PRRAGEngine:
             raise ValueError(f"Git provider not found for PR URL: {self.pr_url}")
 
         return self.index_manager._get_pr_base_index_name(git_provider)
-    
-    async def get_request_max_tokens(self, max_tokens: int, system: str = "", user: str = ""):
-        """
-        Get the maximum tokens allowed for the request based on the model and rag buffer.
-
-        Returns:
-            int: The maximum tokens allowed for the request.
-
-        Raises:
-            ValueError: If the model is not supported.
-        """
-
-        git_provider = self.index_manager._get_git_provider(self.pr_url)
-        if not git_provider:
-            raise ValueError(f"Git provider not found for PR URL: {self.pr_url}")
-
-        token_handler = TokenHandler(git_provider.pr, {}, system, user)
-        return max_tokens - token_handler.prompt_tokens - RAG_BUFFER_TOKENS
 
     async def query(self, query: str, llm_temperature: float = 0.7, llm_max_tokens: int = 1000, top_k: int = 5):
         """


### PR DESCRIPTION
This PR adds a `max_diff_context_percent` configuration field that sets the max amount of context a diff can take up. This allows us to stop pr agent from filling the entire context so the RAGEngine can add more relevant documents to the LLM request. 